### PR TITLE
bump electron prebuilt to ^0.37.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
   },
   "homepage": "https://github.com/electron/electron-quick-start#readme",
   "devDependencies": {
-    "electron-prebuilt": "^0.37.7"
+    "electron-prebuilt": "^0.37.8"
   }
 }


### PR DESCRIPTION
I just discovered that `electron-prebuilt` is kept up to date automatically!

From http://maxogden.com/electron-fundamentals.html

> I'd also like to give a shoutout to John Muhl who wrote [electron-prebuilt-updater](https://github.com/johnmuhl/electron-prebuilt-updater), which runs on a free Heroku server, listens for GitHub Releases on Electron with a WebHook and automatically does an NPM publish to `electron-prebuilt` with the new release. It's an awesome bit of automation that has saved me a lot of maintenance time!

@jlord 