### PR TITLE
Use new electron version and clean up package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,22 +6,16 @@
   "scripts": {
     "start": "electron ."
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/electron/electron-quick-start.git"
-  },
+  "repository": "https://github.com/electron/electron-quick-start",
   "keywords": [
     "Electron",
     "quick",
     "start",
-    "tutorial"
+    "tutorial",
+    "demo"
   ],
   "author": "GitHub",
   "license": "CC0-1.0",
-  "bugs": {
-    "url": "https://github.com/electron/electron-quick-start/issues"
-  },
-  "homepage": "https://github.com/electron/electron-quick-start#readme",
   "devDependencies": {
     "electron": "^1.4.1"
   }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
   },
   "homepage": "https://github.com/electron/electron-quick-start#readme",
   "devDependencies": {
-    "electron": "^1.3.4"
+    "electron": "^1.4.1"
   }
 }


### PR DESCRIPTION
npm falls back to `repository` if `homepage` is absent, so this value was redundant. Also the npm website infers the issues URL automatically for GitHub-based packages.