### PR TITLE
OS X Human Interface Guidelines fix

### DIFF
--- a/main.js
+++ b/main.js
@@ -34,11 +34,7 @@ app.on('ready', createWindow)
 
 // Quit when all windows are closed.
 app.on('window-all-closed', function () {
-  // On OS X it is common for applications and their menu bar
-  // to stay active until the user quits explicitly with Cmd + Q
-  if (process.platform !== 'darwin') {
     app.quit()
-  }
 })
 
 app.on('activate', function () {


### PR DESCRIPTION
This line got my app rejected from the app store because it was a single window app.
I think the quick start app should be simple...
Apple's mac store guidelines:

> if the application is a single-window app, it might be appropriate to save data and quit the app when the main window is closed.
