### PR TITLE
Format URL passed to BrowserWindow.loadURL

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,10 @@ To clone and run this repository you'll need [Git](https://git-scm.com) and [Nod
 git clone https://github.com/electron/electron-quick-start
 # Go into the repository
 cd electron-quick-start
-# Install dependencies and run the app
-npm install && npm start
+# Install dependencies
+npm install
+# Run the app
+npm start
 ```
 
 Learn more about Electron and its API in the [documentation](http://electron.atom.io/docs/latest).

--- a/main.js
+++ b/main.js
@@ -4,6 +4,8 @@ const app = electron.app
 // Module to create native browser window.
 const BrowserWindow = electron.BrowserWindow
 
+const url = require('url')
+
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.
 let mainWindow
@@ -13,7 +15,11 @@ function createWindow () {
   mainWindow = new BrowserWindow({width: 800, height: 600})
 
   // and load the index.html of the app.
-  mainWindow.loadURL(`file://${__dirname}/index.html`)
+  mainWindow.loadURL(url.format({
+    pathname: __dirname + '/index.html',
+    protocol: 'file:',
+    slashes: true
+  }))
 
   // Open the DevTools.
   mainWindow.webContents.openDevTools()

--- a/main.js
+++ b/main.js
@@ -4,6 +4,7 @@ const app = electron.app
 // Module to create native browser window.
 const BrowserWindow = electron.BrowserWindow
 
+const path = require('path')
 const url = require('url')
 
 // Keep a global reference of the window object, if you don't, the window will
@@ -16,7 +17,7 @@ function createWindow () {
 
   // and load the index.html of the app.
   mainWindow.loadURL(url.format({
-    pathname: __dirname + '/index.html',
+    pathname: path.join(__dirname, 'index.html'),
     protocol: 'file:',
     slashes: true
   }))


### PR DESCRIPTION
Currently, if your app's folder contains certain special URL characters (such as `?`) then the quick start app does not work because those values aren't properly encoded before passing the URL to `BrowserWindow.loadURL`.

### Steps to reproduce

- Clone this repository into a folder called `quick?start`
- Run `npm start`
- Fails with an error like `Not allowed to load local resource: file:///Users/kevin/github/electron-scratch/quick?start/index.html`

/cc @zeke 