### PR TITLE
Place <script> in <body>

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,10 +10,10 @@
     We are using Node.js <script>document.write(process.versions.node)</script>,
     Chromium <script>document.write(process.versions.chrome)</script>,
     and Electron <script>document.write(process.versions.electron)</script>.
-  </body>
 
-  <script>
-    // You can also require other files to run in this process
-    require('./renderer.js')
-  </script>
+    <script>
+      // You can also require other files to run in this process
+      require('./renderer.js')
+    </script>
+  </body>
 </html>


### PR DESCRIPTION
`<script>` was placed in `<html>`, which is not valid HTML (according to [W3C validator](http://validator.w3.org/)). It is now placed at the end of `<body>`.