### PR TITLE
bump electron devDependencies to 1.8.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,6 @@
   "author": "GitHub",
   "license": "CC0-1.0",
   "devDependencies": {
-    "electron": "~1.7.8"
+    "electron": "~1.8.2"
   }
 }


### PR DESCRIPTION
now that we have a stable 1.8.x version in npm, bump our dependency from 1.7.x to 1.8.x