### PR TITLE
Change .js extension to .ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,6 @@
   "author": "GitHub",
   "license": "CC0-1.0",
   "devDependencies": {
-    "electron": "~1.7.8"
+    "electron": "~1.8.2"
   }
 }


### PR DESCRIPTION
Yes we still use .js extension but in some intelligent editors like webstrom it shows too many errors because it didn't recognized typescript syntax in .js extension, and i believe almost every editor have support to typescript so we must need to change .js extension to .ts

https://github.com/electron/electron-quick-start/issues/190