### PR TITLE
workaround for the quickstart to work again on debian 9

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,6 +1,12 @@
 // Modules to control application life and create native browser window
 const {app, BrowserWindow} = require('electron')
 
+// temporary workaround until the issue
+// https://github.com/electron/electron/issues/13415
+// is fixed
+app.disableHardwareAcceleration()
+
+
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.
 let mainWindow


### PR DESCRIPTION
a temporary solution to solves #224 until issue is corrected on electron main project (https://github.com/electron/electron/issues/13415)