### PR TITLE
chore: update comments to refer to 'macOS' instead of 'OS X'

### DIFF
--- a/main.js
+++ b/main.js
@@ -31,7 +31,7 @@ app.on('ready', createWindow)
 
 // Quit when all windows are closed.
 app.on('window-all-closed', function () {
-  // On OS X it is common for applications and their menu bar
+  // On macOS it is common for applications and their menu bar
   // to stay active until the user quits explicitly with Cmd + Q
   if (process.platform !== 'darwin') {
     app.quit()
@@ -39,7 +39,7 @@ app.on('window-all-closed', function () {
 })
 
 app.on('activate', function () {
-  // On OS X it's common to re-create a window in the app when the
+  // On macOS it's common to re-create a window in the app when the
   // dock icon is clicked and there are no other windows open.
   if (mainWindow === null) {
     createWindow()


### PR DESCRIPTION
OS X is no longer the name of Apple's Mac operating system, it was changed to macOS at WWDC 2016 