### PR TITLE
style: Simplify if statements

### DIFF
--- a/main.js
+++ b/main.js
@@ -39,17 +39,13 @@ app.on('ready', createWindow)
 app.on('window-all-closed', function () {
   // On macOS it is common for applications and their menu bar
   // to stay active until the user quits explicitly with Cmd + Q
-  if (process.platform !== 'darwin') {
-    app.quit()
-  }
+  if (process.platform !== 'darwin') app.quit()
 })
 
 app.on('activate', function () {
   // On macOS it's common to re-create a window in the app when the
   // dock icon is clicked and there are no other windows open.
-  if (mainWindow === null) {
-    createWindow()
-  }
+  if (mainWindow === null) createWindow()
 })
 
 // In this file you can include the rest of your app's specific main process


### PR DESCRIPTION
In this PR, I simplified the IF statements by removing the curcly braces and removing the indent. 

In other words, I turned this:
```js
if (process.platform !== 'darwin') {
  app.quit()
}
```
into this:
```js
if (process.platform !== 'darwin') app.quit()
```