### PR TITLE
fix: faulty preload selector assumptions

### DIFF
--- a/preload.js
+++ b/preload.js
@@ -1,7 +1,12 @@
 // All of the Node.js APIs are available in the preload process.
 // It has the same sandbox as a Chrome extension.
 window.addEventListener('DOMContentLoaded', () => {
-  for (const versionType of ['chrome', 'electron', 'node']) {
-    document.getElementById(`${versionType}-version`).innerText = process.versions[versionType]
+  const replaceText = (selector, text) => {
+    const element = document.getElementById(selector)
+    if (element) element.innerText = text
+  } 
+  
+  for (const type of ['chrome', 'node', 'electron']) {
+    replaceText(`${type}-version`, process.versions[type])
   }
 })


### PR DESCRIPTION
Closes https://github.com/electron/electron-quick-start/issues/295.

This preload script previously assumed these elements to be present in the DOM, which is not the case if any other page is loaded. This corrects that issue by only attempting to replace the `innerText` if the element is non-null.

cc @malept 