### PR TITLE
chore: renderer has no access to Node APIs.

### DIFF
--- a/renderer.js
+++ b/renderer.js
@@ -1,3 +1,6 @@
 // This file is required by the index.html file and will
 // be executed in the renderer process for that window.
-// All of the Node.js APIs are available in this process.
+// No Node.js APIs are available in this process because
+// `nodeIntegration` is turned off. Use `preload.js` to
+// selectively enable features needed in the rendering
+// process.


### PR DESCRIPTION
It seems like this comment was left in `renderer.js` from an earlier version. Corrected it to the best of my ability. Let me know if I've misunderstood something.