### PR TITLE
security: add csp

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,9 @@
 <html>
   <head>
     <meta charset="UTF-8">
+    <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'">
+    <meta http-equiv="X-Content-Security-Policy" content="default-src 'self'; script-src 'self'">
     <title>Hello World!</title>
   </head>
   <body>


### PR DESCRIPTION
Closes https://github.com/electron/electron-quick-start/issues/333.

Adds a CSP so that the default does not throw console warnings. Also includes a link to CSP documentation.

cc @jkleinsc 