### PR TITLE
Two workarounds to buffer_manager.cc(488) error

### DIFF
--- a/main.js
+++ b/main.js
@@ -2,6 +2,8 @@
 const {app, BrowserWindow} = require('electron')
 const path = require('path')
 
+process.stderr;
+
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.
 let mainWindow

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A minimal Electron application",
   "main": "main.js",
   "scripts": {
+    "start_no_gpu": "electron --disable-gpu .",
     "start": "electron ."
   },
   "repository": "https://github.com/electron/electron-quick-start",


### PR DESCRIPTION
This pull request should not be merged. It is merely a way to present workarounds I have found to errors, for consideration, feedback and perhaps a more appropriate fix.

I tried electron-quick-start on a Linux Mint system and got errors on the console when the app started and again each time a menu was opened, like the following:

[20940:0128/142811.334410:ERROR:buffer_manager.cc(488)] [.DisplayCompositor]GL ERROR :GL_INVALID_OPERATION : glBufferData: <- error from previous GL command

Similar error was reported at https://stackoverflow.com/questions/58347778/electron-fix-errorbuffer-manager-cc488-displaycompositorgl-error-gl-inv/59940566#59940566 and the provided solution of disabling GPU worked for me too, but I then tried [electron-boilerplate](https://github.com/sindresorhus/electron-boilerplate) and did not get the errors, even without disabling GPU.

Comparing electron-boilerplate and electron-quick-start, I have isolated the difference to invoking `process.stderr`.

I don't know why the error occurs or why either of the workarounds works to prevent the error, let alone why two such different workarounds both work. I am curious to understand better how they work and in particular why invoking `process.stderr` works, but I am not adept enough to understand the nodejs source code, to determine what `process.stderr` is actually doing - what side effects it has.