### PR TITLE
refactor: use app.whenReady(), not of .once(ready)

### DIFF
--- a/main.js
+++ b/main.js
@@ -22,7 +22,7 @@ function createWindow () {
 // This method will be called when Electron has finished
 // initialization and is ready to create browser windows.
 // Some APIs can only be used after this event occurs.
-app.on('ready', createWindow)
+app.whenReady().then(createWindow)
 
 // Quit when all windows are closed.
 app.on('window-all-closed', function () {


### PR DESCRIPTION
Similar to https://github.com/electron/electron/pull/21972: prefer `app.whenReady(...)` over `app.one('ready', ...)` for the minor advantage of not leaving a live-but-never-agan-used event handler laying around.

CC @codebytere 