### PR TITLE
docs: fix explanation of darwin auto-quit prevention

### DIFF
--- a/main.js
+++ b/main.js
@@ -32,10 +32,10 @@ app.whenReady().then(() => {
   })
 })
 
-// Quit when all windows are closed.
+// Quit when all windows are closed, except on macOS. There, it's common
+// for applications and their menu bar to stay active until the user quits
+// explicitly with Cmd + Q.
 app.on('window-all-closed', function () {
-  // On macOS it is common for applications and their menu bar
-  // to stay active until the user quits explicitly with Cmd + Q
   if (process.platform !== 'darwin') app.quit()
 })
 


### PR DESCRIPTION
I fixed the comment above the auto-quit prevention for macOS.
Before it suggested the code quits the app, now it says the code prevents the app from quitting.

**Note**: This same pull request was on [Electron \#24003](https://github.com/electron/electron/pull/24003). I added it here too for consistency.