### PR TITLE
fix: handles installs on Ubuntu on Windows by forcing windows binaries

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "A minimal Electron application",
   "main": "main.js",
   "scripts": {
-    "start": "electron ."
+    "start": "electron .",
+    "install-wsl": "npm install && npm uninstall electron && export npm_config_platform=win32 && npm install electron && unset npm_config_platform"
   },
   "repository": "https://github.com/electron/electron-quick-start",
   "keywords": [


### PR DESCRIPTION
Related to this issue: https://github.com/electron/electron-quick-start/issues/109 & uses solution from this issue: https://github.com/electron-userland/electron-prebuilt/issues/260