### PR TITLE
docs: Add resources for learning electron

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Note: If you're using Linux Bash for Windows, [see this guide](https://www.howto
 - [electron/simple-samples](https://github.com/electron/simple-samples) - small applications with ideas for taking them further
 - [electron/electron-api-demos](https://github.com/electron/electron-api-demos) - an Electron app that teaches you how to use Electron
 - [hokein/electron-sample-apps](https://github.com/hokein/electron-sample-apps) - small demo apps for the various Electron APIs
+- [fauzan121002/electron-event-emitter](https://github.com/fauzan121002/electron-event-emitter) - an Electron event emitter template with node integration
 
 ## License
 


### PR DESCRIPTION
Would you like to accept my repository for example using emitter events with node integration?

I'm using the latest electron version of the electron quick start.