### PR TITLE
feat: enableRemote in main.js

### DIFF
--- a/main.js
+++ b/main.js
@@ -8,7 +8,8 @@ function createWindow () {
     width: 800,
     height: 600,
     webPreferences: {
-      preload: path.join(__dirname, 'preload.js')
+      preload: path.join(__dirname, 'preload.js'),
+      // enableRemoteModule: true
     }
   })
 


### PR DESCRIPTION
Added props for remote module enabling in webPreferences. This is required for IPC among renderer processes.