### PR TITLE
chore: update comments in quick-start

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
     Chromium <span id="chrome-version"></span>,
     and Electron <span id="electron-version"></span>.
 
-    <!-- You can also require other files to run in this process -->
+    <!-- You can also include other files to run in this process -->
     <script src="./renderer.js"></script>
   </body>
 </html>

--- a/preload.js
+++ b/preload.js
@@ -1,12 +1,15 @@
 // All of the Node.js APIs are available in the preload process.
-// It has the same sandbox as a Chrome extension.
+// The preload script runs in an isolated world by default, similar
+// to content scripts in a Chrome Extension.
+// https://developer.chrome.com/docs/extensions/mv3/content_scripts/#isolated_world
+
 window.addEventListener('DOMContentLoaded', () => {
   const replaceText = (selector, text) => {
     const element = document.getElementById(selector)
     if (element) element.innerText = text
   }
 
-  for (const type of ['chrome', 'node', 'electron']) {
-    replaceText(`${type}-version`, process.versions[type])
+  for (const dependency of ['chrome', 'node', 'electron']) {
+    replaceText(`${dependency}-version`, process.versions[dependency])
   }
 })

--- a/renderer.js
+++ b/renderer.js
@@ -1,6 +1,6 @@
-// This file is required by the index.html file and will
+// This file is included by the index.html file and will
 // be executed in the renderer process for that window.
 // No Node.js APIs are available in this process because
-// `nodeIntegration` is turned off. Use `preload.js` to
-// selectively enable features needed in the rendering
-// process.
+// `nodeIntegration` is turned off and `contextIsolation`
+// is turned on. Use `preload.js` to selectively enable
+// features needed in the renderer process.


### PR DESCRIPTION
After looking at our quick-start app for a while, I've noticed a few things that need updating:

* We used to use `nodeIntegration` and use `require()` API to import `renderer.js`. Since this is no longer the case, I've removed usage of the word "require".
* Added a note on `contextIsolation`.
* Changed a variable from `type` to `dependency` to avoid any possible confusion with TypeScript's `type` reserved keyword.

Open to suggestions!