### PR TITLE
fix: remove X-Content-Security-Policy header

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,6 @@
     <meta charset="UTF-8">
     <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'">
-    <meta http-equiv="X-Content-Security-Policy" content="default-src 'self'; script-src 'self'">
     <title>Hello World!</title>
   </head>
   <body>


### PR DESCRIPTION
Per https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP :

> (Sometimes you may see mentions of the `X-Content-Security-Policy` header, but that's an older version and you don't need to specify it anymore.)