### PR TITLE
Fix: in renderer process, exit after first test failure or after all tests are complete

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,9 +9,6 @@
   </head>
   <body>
     <h1>Hello World!</h1>
-    We are using Node.js <span id="node-version"></span>,
-    Chromium <span id="chrome-version"></span>,
-    and Electron <span id="electron-version"></span>.
 
     <!-- You can also require other files to run in this process -->
     <script src="./renderer.js"></script>

--- a/main.js
+++ b/main.js
@@ -46,6 +46,6 @@ function testDone(success, ...logs) {
   const failIfBadExit = (details) => {
     if (details.reason !== 'clean-exit') testDone(false, new Error('trace'), details)
   }
-  app.on('child-process-gone', (_ev, details) => test.failIfBadExit(details))
-  app.on('render-process-gone', (_ev, _, details) => test.failIfBadExit(details))
+  app.on('child-process-gone', (_ev, details) => failIfBadExit(details))
+  app.on('render-process-gone', (_ev, _, details) => failIfBadExit(details))
 }

--- a/main.js
+++ b/main.js
@@ -1,28 +1,22 @@
 // Modules to control application life and create native browser window
-const {app, BrowserWindow} = require('electron')
+const {app, crashReporter, ipcMain, BrowserWindow} = require('electron')
 const path = require('path')
 
 function createWindow () {
   // Create the browser window.
   const mainWindow = new BrowserWindow({
-    width: 800,
-    height: 600,
     webPreferences: {
       preload: path.join(__dirname, 'preload.js')
     }
   })
-
-  // and load the index.html of the app.
-  mainWindow.loadFile('index.html')
-
-  // Open the DevTools.
-  // mainWindow.webContents.openDevTools()
+  mainWindow.loadFile('index.html');
 }
 
 // This method will be called when Electron has finished
 // initialization and is ready to create browser windows.
 // Some APIs can only be used after this event occurs.
 app.whenReady().then(() => {
+
   createWindow()
   
   app.on('activate', function () {
@@ -39,5 +33,19 @@ app.on('window-all-closed', function () {
   if (process.platform !== 'darwin') app.quit()
 })
 
-// In this file you can include the rest of your app's specific main process
-// code. You can also put them in separate files and require them here.
+
+function testDone(success, ...logs) {
+  console.log(`test ${success ? 'passed' : 'failed'}`)
+  logs.forEach((i) => console.log(i))
+  process.exit(success ? 0 : 1)
+}
+
+{
+  crashReporter.start({ uploadToServer: false, submitURL: '' })
+  ipcMain.on('test-done', (_, success, ...logs) => testDone(success, ...logs))
+  const failIfBadExit = (details) => {
+    if (details.reason !== 'clean-exit') testDone(false, new Error('trace'), details)
+  }
+  app.on('child-process-gone', (_ev, details) => test.failIfBadExit(details))
+  app.on('render-process-gone', (_ev, _, details) => test.failIfBadExit(details))
+}

--- a/preload.js
+++ b/preload.js
@@ -1,12 +1,32 @@
 // All of the Node.js APIs are available in the preload process.
 // It has the same sandbox as a Chrome extension.
-window.addEventListener('DOMContentLoaded', () => {
-  const replaceText = (selector, text) => {
-    const element = document.getElementById(selector)
-    if (element) element.innerText = text
-  }
 
-  for (const type of ['chrome', 'node', 'electron']) {
-    replaceText(`${type}-version`, process.versions[type])
+// Test helpers
+const test = {
+  assert: (ok, ...logs) => {
+    if (!ok) test.fail(...logs)
+  },
+  fail: (...logs) => test.done(false, ...logs),
+  done: (success = true, ...logs) => {
+    if (!success) logs.unshift(new Error('test failed'))
+    require('electron').ipcRenderer.send('test-done', success, ...logs)
+  },
+}
+
+// Example test: check that process.versions.electron
+// - is defined in the preload process
+// - has major, minor, and patch numbers
+// - the numbers are non-negative
+try {
+  const ver = process.versions.electron
+  const tokens = process.versions.electron.split('.', 3)
+  test.assert(tokens.length === 3)
+  for (const token of tokens) {
+    const num = Number.parseInt(token)
+    test.assert(num !== NaN)
+    test.assert(num >= 0)
   }
-})
+  test.done()
+} catch (err) {
+  test.fail(err)
+}

--- a/preload.js
+++ b/preload.js
@@ -10,6 +10,7 @@ const test = {
   done: (success = true, ...logs) => {
     if (!success) logs.unshift(new Error('test failed'))
     require('electron').ipcRenderer.send('test-done', success, ...logs)
+    process.exit(success ? 0 : 1)
   },
 }
 


### PR DESCRIPTION
Fixes a use case like this:

```js
test.assert(foo());
test.done();
```

Let's say `foo()` returns false which triggers an ipcRenderer.send('test-done') event. The issue here is that, since control flow continues in the renderer even after the test failure, you can wind up having two ipc `test-done` calls -- one indicating failure (from `foo()`'s failure), and one indicating success (from `test.done()`.

The first message is usually processed quickly enough that the test application exits before the false-success from `test.done()` is handled by the main process. But there is no guaranteed. For whatever reason, 11.4.x nearly always gets the second `test-done` event before exiting, causing those versions to often show false successes.

Another fix would be to use `sendSync()` instead of `send()`