### PR TITLE
fix: exit after all tests done or after test fail

### DIFF
--- a/preload.js
+++ b/preload.js
@@ -10,6 +10,7 @@ const test = {
   done: (success = true, ...logs) => {
     if (!success) logs.unshift(new Error('test failed'))
     require('electron').ipcRenderer.send('test-done', success, ...logs)
+    process.exit(success ? 0 : 1)
   },
 }
 


### PR DESCRIPTION
Fixes a use case like this:

```js
test.assert(foo());
test.done();
```

Let's say `foo()` returns false which triggers an ipcRenderer.send('test-done') event. The issue here is that, since control flow continues in the renderer even after the test failure, you can wind up having two ipc `test-done` calls -- one indicating failure (from `foo()`'s failure), and one indicating success (from `test.done()`.

The first message is usually processed quickly enough that the test application exits before the false-success from `test.done()` is handled by the main process. But there is no guaranteed. For whatever reason, 11.4.x nearly always gets the second `test-done` event before exiting, causing those versions to often show false successes.

Another fix would be to use `sendSync()` instead of `send()`

CC @nornagon, who I know has been interested in these tests but for some reason I can't flag him as a reviewer :confused: 