### PR TITLE
fix: do not start crashReporter on < Electron 10

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,6 +1,7 @@
 // Modules to control application life and create native browser window
 const {app, crashReporter, ipcMain, BrowserWindow} = require('electron')
 const path = require('path')
+const electronMajor = Number.parseInt(process.versions.electron);
 
 function createWindow () {
   // Create the browser window.
@@ -41,7 +42,9 @@ function testDone(success, ...logs) {
 }
 
 {
-  crashReporter.start({ uploadToServer: false, submitURL: '' })
+  if (electronMajor > 8)
+    crashReporter.start({ uploadToServer: false, submitURL: '' })
+
   ipcMain.on('test-done', (_, success, ...logs) => testDone(success, ...logs))
   const failIfBadExit = (details) => {
     if (details.reason !== 'clean-exit') testDone(false, new Error('trace'), details)

--- a/main.js
+++ b/main.js
@@ -42,7 +42,7 @@ function testDone(success, ...logs) {
 }
 
 {
-  if (electronMajor > 8)
+  if (electronMajor >= 10) // companyName required before v10
     crashReporter.start({ uploadToServer: false, submitURL: '' })
 
   ipcMain.on('test-done', (_, success, ...logs) => testDone(success, ...logs))


### PR DESCRIPTION
if the current test template is run on older versions of Electron, it will error out with

> "Error: companyName is a required option to crashReporter.start"

The template works in Electron 10 due to @nornagon's [update](https://github.com/electron/electron/commit/06bf0d08dc3c941ccce0dfb0f9e0e146d9232605) which is [described](https://github.com/electron/electron/blob/main/docs/breaking-changes.md#deprecated-companyname-argument-to-crashreporterstart) in the breaking changes doc:

> The companyName argument to crashReporter.start(), which was previously required, is now optional, and further, is deprecated. To get the same behavior in a non-deprecated way, you can pass a companyName value in globalExtra.

Since the test template will ideally work on whatever version of Electron we throw at it, this PR changes the behavior to only start crashReporter iff running on Electron 10 or higher.