### PR TITLE
CORS: Allow inline CSS and style attributes

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8">
     <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'">
     <link href="./styles.css" rel="stylesheet">
     <title>Hello World!</title>
   </head>


### PR DESCRIPTION
This change will allow fiddle users and people using the quickstart to add inline `style` elements and `style` attributes, making it easier to quickly style without significantly damaging CORS.

We could also consider `script-src-attr` to only allow `style` attributes but I think allowing inline style elements would be useful as well. 