### PR TITLE
fix: Update Typography in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ This is a minimal Electron application based on the [Quick Start Guide](https://
 
 A basic Electron application needs just these files:
 
-- `package.json` - Points to the app’s main file and lists its details and dependencies.
-- `main.js` - Starts the app and creates a browser window to render HTML. This is the app’s **main process**.
-- `index.html` - A web page to render. This is the app’s **renderer process**.
+- `package.json` — Points to the app’s main file and lists its details and dependencies.
+- `main.js` — Starts the app and creates a browser window to render HTML. This is the app’s **main process**.
+- `index.html` — A web page to render. This is the app’s **renderer process**.
 
 You can learn more about each of these components within the [Quick Start Guide](https://electronjs.org/docs/latest/tutorial/quick-start).
 
@@ -33,12 +33,12 @@ Note: If you’re using Linux Bash for Windows, [see this guide](https://www.how
 
 ## Resources for Learning Electron
 
-- [electronjs.org/docs](https://electronjs.org/docs) - all of Electron’s documentation
-- [electronjs.org/community#boilerplates](https://electronjs.org/community#boilerplates) - sample starter apps created by the community
-- [electron/electron-quick-start](https://github.com/electron/electron-quick-start) - a very basic starter Electron app
-- [electron/simple-samples](https://github.com/electron/simple-samples) - small applications with ideas for taking them further
-- [electron/electron-api-demos](https://github.com/electron/electron-api-demos) - an Electron app that teaches you how to use Electron
-- [hokein/electron-sample-apps](https://github.com/hokein/electron-sample-apps) - small demo apps for the various Electron APIs
+- [electronjs.org/docs](https://electronjs.org/docs) — all of Electron’s documentation
+- [electronjs.org/community#boilerplates](https://electronjs.org/community#boilerplates) — sample starter apps created by the community
+- [electron/electron-quick-start](https://github.com/electron/electron-quick-start) — a very basic starter Electron app
+- [electron/simple-samples](https://github.com/electron/simple-samples) — small applications with ideas for taking them further
+- [electron/electron-api-demos](https://github.com/electron/electron-api-demos) — an Electron app that teaches you how to use Electron
+- [hokein/electron-sample-apps](https://github.com/hokein/electron-sample-apps) — small demo apps for the various Electron APIs
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -8,15 +8,15 @@ This is a minimal Electron application based on the [Quick Start Guide](https://
 
 A basic Electron application needs just these files:
 
-- `package.json` - Points to the app's main file and lists its details and dependencies.
-- `main.js` - Starts the app and creates a browser window to render HTML. This is the app's **main process**.
-- `index.html` - A web page to render. This is the app's **renderer process**.
+- `package.json` - Points to the app’s main file and lists its details and dependencies.
+- `main.js` - Starts the app and creates a browser window to render HTML. This is the app’s **main process**.
+- `index.html` - A web page to render. This is the app’s **renderer process**.
 
 You can learn more about each of these components within the [Quick Start Guide](https://electronjs.org/docs/latest/tutorial/quick-start).
 
 ## To Use
 
-To clone and run this repository you'll need [Git](https://git-scm.com) and [Node.js](https://nodejs.org/en/download/) (which comes with [npm](http://npmjs.com)) installed on your computer. From your command line:
+To clone and run this repository you’ll need [Git](https://git-scm.com) and [Node.js](https://nodejs.org/en/download/) (which comes with [npm](http://npmjs.com)) installed on your computer. From your command line:
 
 ```bash
 # Clone this repository
@@ -29,11 +29,11 @@ npm install
 npm start
 ```
 
-Note: If you're using Linux Bash for Windows, [see this guide](https://www.howtogeek.com/261575/how-to-run-graphical-linux-desktop-applications-from-windows-10s-bash-shell/) or use `node` from the command prompt.
+Note: If you’re using Linux Bash for Windows, [see this guide](https://www.howtogeek.com/261575/how-to-run-graphical-linux-desktop-applications-from-windows-10s-bash-shell/) or use `node` from the command prompt.
 
 ## Resources for Learning Electron
 
-- [electronjs.org/docs](https://electronjs.org/docs) - all of Electron's documentation
+- [electronjs.org/docs](https://electronjs.org/docs) - all of Electron’s documentation
 - [electronjs.org/community#boilerplates](https://electronjs.org/community#boilerplates) - sample starter apps created by the community
 - [electron/electron-quick-start](https://github.com/electron/electron-quick-start) - a very basic starter Electron app
 - [electron/simple-samples](https://github.com/electron/simple-samples) - small applications with ideas for taking them further


### PR DESCRIPTION
Hyphens used in places where a colon is appropriate requires an em dash in proper typography. These have been replaced.

Straight single quotes — sometimes referred to as foot marks — are mistakenly used as apostrophes, or close single quotes, in this `README`. These have been replaced here, also.