### PR TITLE
chore: lint JS with standard

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,5 +1,5 @@
 // Modules to control application life and create native browser window
-const {app, BrowserWindow} = require('electron')
+const { app, BrowserWindow } = require('electron')
 const path = require('path')
 
 function createWindow () {

--- a/preload.js
+++ b/preload.js
@@ -2,7 +2,7 @@
  * The preload script runs before. It has access to web APIs
  * as well as Electron's renderer process modules and some
  * polyfilled Node.js functions.
- * 
+ *
  * https://www.electronjs.org/docs/latest/tutorial/sandbox
  */
 window.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
These files had become inconsistent with the code examples in the documentation on the website since those are linted with `standard`.