### PR TITLE
fix: clarifies what preload script runs before

### DIFF
--- a/preload.js
+++ b/preload.js
@@ -1,7 +1,8 @@
 /**
- * The preload script runs before. It has access to web APIs
- * as well as Electron's renderer process modules and some
- * polyfilled Node.js functions.
+ * The preload script runs before `index.html` is loaded
+ * in the renderer. It has access to web APIs as well as
+ * Electron's renderer process modules and some polyfilled
+ * Node.js functions.
  *
  * https://www.electronjs.org/docs/latest/tutorial/sandbox
  */


### PR DESCRIPTION
Simple text change to the comment at the top of the the default preload.js file. Clarifies what the preload script runs before.

<img width="1438" alt="Screenshot 2024-02-23 at 12 16 11 PM" src="https://github.com/electron/electron-quick-start/assets/14120490/d86a74c4-3b27-40d7-a5a5-2de9e7dbbbf3">
